### PR TITLE
fix: enable proper GitHub Pages routing for i18n locales

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,8 @@ jobs:
             --site "${{ steps.pages.outputs.origin }}" \
             --base "${{ steps.pages.outputs.base_path }}"
         working-directory: ${{ env.BUILD_PATH }}
+      - name: Disable Jekyll processing
+        run: touch ${{ env.BUILD_PATH }}/dist/.nojekyll
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
- Add .nojekyll file to repo root to prevent Jekyll processing
- Update build workflow to create .nojekyll in dist before deployment
- Fixes issue where /en/ and /ar/ pages were not loading on GitHub Pages
- GitHub Pages needs this marker to properly serve all static routes