### PR TITLE
fix: include global CSS in locale-specific routes

### DIFF
--- a/src/pages/[locale]/[...path].astro
+++ b/src/pages/[locale]/[...path].astro
@@ -1,9 +1,28 @@
 ---
+import '@/styles/global.css';
 import { configuration, type Locale } from '@/i18n.ts';
 import IndexPage from '../index.astro';
 import AccessibilityPage from '../accessibility.astro';
 import BlogIndexPage from '../blog.astro';
-import BlogPostPage, { getStaticPaths as getBlogStaticPaths } from '../blog/[slug].astro';
+import BlogPostPage, {
+  getStaticPaths as getBlogStaticPaths,
+} from '../blog/[slug].astro';
+import CollaborationsPage from '../collaborations.astro';
+import DatenschutzPage from '../datenschutz.astro';
+import DonatePage from '../donate.astro';
+import ImprintPage from '../imprint.astro';
+import MentoringPage from '../mentoring.astro';
+import NewsletterPage from '../newsletter.astro';
+import PrivacyPolicyPage from '../privacy-policy.md';
+import ReportsPage from '../reports.astro';
+import SocietyPage from '../society.astro';
+import VereinPage from '../verein.astro';
+import WorkshopsPage from '../workshops.astro';
+import NotFoundPage from '../404.astro';
+import BlogIndexPage from '../blog.astro';
+import BlogPostPage, {
+  getStaticPaths as getBlogStaticPaths,
+} from '../blog/[slug].astro';
 import CollaborationsPage from '../collaborations.astro';
 import DatenschutzPage from '../datenschutz.astro';
 import DonatePage from '../donate.astro';
@@ -105,14 +124,8 @@ const isBlogPost = normalizedPath.startsWith('blog/');
 const RoutePage = staticRouteMap[normalizedPath] ?? NotFoundPage;
 ---
 
-{
-  isBlogIndex && <BlogIndexPage />
-}
+{isBlogIndex && <BlogIndexPage />}
 
-{
-  isBlogPost && <BlogPostPage {...Astro.props} />
-}
+{isBlogPost && <BlogPostPage {...Astro.props} />}
 
-{
-  !isBlogIndex && !isBlogPost && <RoutePage />
-}
+{!isBlogIndex && !isBlogPost && <RoutePage />}


### PR DESCRIPTION
Import @/styles/global.css in [...path].astro to ensure CSS is bundled and included in generated /en/ and /ar/ pages. Resolves issue where locale pages loaded without UI/styles despite HTML being present.

The CSS import forces Astro to include all necessary stylesheets in the rendered output for dynamically routed locale pages.