### PR TITLE
Add workflow for deployment to production

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -6,7 +6,7 @@ on:
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 concurrency:
-  group: 'pages'
+  group: 'pages-production'
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,0 +1,39 @@
+name: Deploy Astro site to Production
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      stage: production
+
+  deploy:
+    environment:
+      name: production
+      url: https://coderdojo-schoeneweide.de/
+    needs: build
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: github-pages
+
+      - run: ls -la
+
+      # - name: Push to coderdojo-schoeneweide.github.io repository
+      #   uses: peaceiris/actions-gh-pages@v4
+      #   with:
+      #     deploy_key: ${{ secrets.DEPLOY_KEY }}
+      #     external_repository: Coderdojo-Schoeneweide/coderdojo-schoeneweide.github.io
+      #     publish_branch: master
+      #     publish_dir: ./

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,9 +1,9 @@
-name: Deploy Astro site to Pages
+name: Deploy Astro site to Staging
 
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: [ "master" ]
+    branches: ['master']
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -16,7 +16,7 @@ permissions:
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 concurrency:
-  group: "pages"
+  group: 'pages'
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Adds a new workflow that can be triggered manually via the Actions tab to trigger a deployment to production.

It reuses the existing build workflow to build the page before deploying it to GitHub Pages via the coderdojo-schoeneweide.github.io repository.

The actual deployment step is commented out for now to be able to check whether the downloaded artifact contains the expected files for the deployment.