### PR TITLE
Fix deployment: Extract tar before upload

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -28,9 +28,8 @@ jobs:
         with:
           name: github-pages
 
-      - name: Extract archive
-        run: tar -xvf artifact.tar && rm artifact.tar
-      - run: ls -la
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4
 
       # - name: Push to coderdojo-schoeneweide.github.io repository
       #   uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           name: github-pages
 
+      - name: Extract archive
+        run: tar -xvf artifact.tar && rm artifact.tar
       - run: ls -la
 
       # - name: Push to coderdojo-schoeneweide.github.io repository


### PR DESCRIPTION
The `download artifact` action uncompresses the artifact, but it doesn't extract the contained tar archive automatically, so we have to do this manually before we can upload the extracted files.

See also output of test run at https://github.com/Coderdojo-Schoeneweide/website/actions/runs/24466742834/job/71496019357